### PR TITLE
Clarify subfolder instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 1. Download this repository and unzip it or just copy the ``portraitor.vbs`` file.
 1. Download images from imgur as a zip (3 button menu at the bottom).
-1. unzip the images into a folder named that is not called ``target`` or ``.git``. The folder has to be in the same folder as the ``portraitor.vbs`` file.
+1. unzip the images into a folder named that is not called ``target`` or ``.git``. The folder has to be in the same folder as the ``portraitor.vbs`` file. The script will not work if the images are unzipped to the same directory that contains the ``portraitor.vsb`` file; they need to be in a subfolder.
 1. Execute ``portraitor.vbs``. You might have to refresh (F5) the folder after that. The script will generate portait files for each gallery folder in the same directory as the ``portraitor.vbs`` file.
 1. Copy the folders from ``target`` to ``C:\Users\``_name_``\AppData\LocalLow\Owlcat Games\Pathfinder Kingmaker\Portraits``
 
@@ -12,7 +12,7 @@
 
 This script will fail if:
 
-* There is any folder in the same folder as the script file ``portraitor.vbs`` itself, that doesn't belong to the script and has differnet content.
+* The folder containing ``portraitor.vbs`` contains any subfolders with content other than images in the correct format for conversion. The script will create a folder called ``target`` containing the outputs.
 * The images in the folder don't start with a number followed by a blank
 * The target folder is currently in use (e.g. by the explorer)
 


### PR DESCRIPTION
Thanks for putting this together! I made a couple of tweaks as there was some confusion on [reddit](https://www.reddit.com/r/Pathfinder_Kingmaker/comments/9jpq3b/script_to_import_portaits_from_imgur_galleries/?st=jojtv663&sh=2462df0f#bottom-comments
) about the instructions. 

- Added extra clarity to make it clear that the images need to be unzipped to a separate subfolder
- Tried to address an apparent contradiction (forbidding subfolders not owned by the script and the requirement to put images in a subfolder) with a re-wording.

Hope it's useful.